### PR TITLE
feat: Expose realized order fills and fees

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,37 @@ const orders = await client.fetchOrders({
 });
 ```
 
+`fetchAccountOrders()` and `fetchOrders()` return Schwab's order payloads
+unchanged, including `orderActivityCollection` on terminal orders when Schwab
+populates it. Use `getRealizedFills()` to aggregate serial/partial executions
+and correlate each fill with its order-leg symbol:
+
+```typescript
+import { getOrderFees, getRealizedFills } from "@huskly/schwab-client";
+
+const [order] = await client.fetchAccountOrders(accountHash, {
+  fromEnteredTime,
+  toEnteredTime,
+  status: "FILLED",
+});
+const fills = getRealizedFills(order);
+// [{ legId, instrumentId, symbol, filledQuantity, averageFillPrice }]
+
+const transactions = await client.fetchAccountTransactionHistory(
+  accountHash,
+  fromEnteredTime,
+  toEnteredTime,
+);
+const fees = getOrderFees(order, transactions);
+// { totalFees, items, transactions }
+```
+
+Fee correlation uses `SchwabTransaction.orderId` and only includes `TRADE`
+transactions. Schwab exposes fees on individual `transferItems`; `items`
+preserves their symbols and transfer-item types. The payload does not provide a
+reliable normalized commission-versus-regulatory-fee classification, so callers
+should not infer one from an unlabeled fee.
+
 #### Place an Order
 
 ```typescript

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "format:check": "prettier --check 'src/**/*.ts' 'package.json' 'tsconfig.json'",
     "lint": "eslint src --ext .ts",
     "lint:fix": "eslint src --ext .ts --fix",
+    "test": "npm run build && node --test test/*.test.js",
     "prepublishOnly": "npm run clean && npm run build"
   },
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,14 @@
 // Main client
 export { SchwabClient } from "./schwabClient.js";
 
+// Order economics helpers
+export { getOrderFees, getRealizedFills } from "./orderEconomics.js";
+export type {
+  SchwabOrderFeeItem,
+  SchwabOrderFees,
+  SchwabRealizedFill,
+} from "./orderEconomics.js";
+
 // Types
 export type {
   // Quote types

--- a/src/orderEconomics.ts
+++ b/src/orderEconomics.ts
@@ -1,0 +1,160 @@
+import type { SchwabTransaction } from "./schwabApiTypes.js";
+import type {
+  SchwabExecutionLeg,
+  SchwabOrder,
+  SchwabOrderLeg,
+} from "./types.js";
+
+export interface SchwabRealizedFill {
+  legId?: number;
+  instrumentId?: number;
+  symbol?: string;
+  filledQuantity: number;
+  averageFillPrice: number;
+}
+
+export interface SchwabOrderFeeItem {
+  activityId: number;
+  transactionId?: number;
+  transferItemType?: string;
+  symbol?: string;
+  fee: number;
+}
+
+export interface SchwabOrderFees {
+  orderId: number;
+  totalFees: number;
+  items: SchwabOrderFeeItem[];
+  transactions: SchwabTransaction[];
+}
+
+interface FillAccumulator {
+  legId?: number;
+  instrumentId?: number;
+  symbol?: string;
+  filledQuantity: number;
+  weightedPrice: number;
+}
+
+function matchingOrderLeg(
+  executionLeg: SchwabExecutionLeg,
+  orderLegs: SchwabOrderLeg[],
+): SchwabOrderLeg | undefined {
+  if (executionLeg.legId !== undefined) {
+    const byLegId = orderLegs.find((leg) => leg.legId === executionLeg.legId);
+    if (byLegId) return byLegId;
+  }
+
+  if (executionLeg.instrumentId !== undefined) {
+    const byInstrumentId = orderLegs.find(
+      (leg) => leg.instrument?.instrumentId === executionLeg.instrumentId,
+    );
+    if (byInstrumentId) return byInstrumentId;
+  }
+
+  return orderLegs.length === 1 ? orderLegs[0] : undefined;
+}
+
+/**
+ * Aggregate an order's EXECUTION activities into one realized fill per order
+ * leg. Only execution legs with finite, positive quantities and finite prices
+ * are included.
+ */
+export function getRealizedFills(order: SchwabOrder): SchwabRealizedFill[] {
+  const orderLegs = order.orderLegCollection ?? [];
+  const fills = new Map<string, FillAccumulator>();
+
+  for (const activity of order.orderActivityCollection ?? []) {
+    if (activity.activityType !== "EXECUTION") continue;
+
+    for (const executionLeg of activity.executionLegs ?? []) {
+      const { price, quantity } = executionLeg;
+      if (
+        price === undefined ||
+        quantity === undefined ||
+        !Number.isFinite(price) ||
+        !Number.isFinite(quantity) ||
+        quantity <= 0
+      ) {
+        continue;
+      }
+
+      const orderLeg = matchingOrderLeg(executionLeg, orderLegs);
+      const legId = executionLeg.legId ?? orderLeg?.legId;
+      const instrumentId =
+        executionLeg.instrumentId ?? orderLeg?.instrument?.instrumentId;
+      const key =
+        legId !== undefined
+          ? `leg:${String(legId)}`
+          : instrumentId !== undefined
+            ? `instrument:${String(instrumentId)}`
+            : orderLegs.length === 1
+              ? "single-leg"
+              : undefined;
+
+      // An execution leg without any usable correlation identifier cannot be
+      // safely attributed in a multi-leg order.
+      if (!key) continue;
+
+      const existing = fills.get(key) ?? {
+        legId,
+        instrumentId,
+        symbol: orderLeg?.instrument?.symbol,
+        filledQuantity: 0,
+        weightedPrice: 0,
+      };
+      existing.filledQuantity += quantity;
+      existing.weightedPrice += price * quantity;
+      fills.set(key, existing);
+    }
+  }
+
+  return [...fills.values()].map(
+    ({ weightedPrice, ...fill }): SchwabRealizedFill => ({
+      ...fill,
+      averageFillPrice: weightedPrice / fill.filledQuantity,
+    }),
+  );
+}
+
+/**
+ * Correlate TRADE transactions and their fee-bearing transfer items to an
+ * order. Fee categories are preserved exactly as Schwab returns them; the API
+ * does not expose a reliable normalized commission/regulatory-fee breakdown.
+ */
+export function getOrderFees(
+  order: SchwabOrder | number,
+  transactions: readonly SchwabTransaction[],
+): SchwabOrderFees {
+  const orderId = typeof order === "number" ? order : order.orderId;
+  if (orderId === undefined || !Number.isFinite(orderId)) {
+    throw new Error("A valid order id is required to correlate order fees");
+  }
+
+  const matchingTransactions = transactions.filter(
+    (transaction) =>
+      transaction.orderId === orderId && transaction.type === "TRADE",
+  );
+  const items = matchingTransactions.flatMap((transaction) =>
+    (transaction.transferItems ?? []).flatMap((item): SchwabOrderFeeItem[] =>
+      item.fee === undefined || !Number.isFinite(item.fee)
+        ? []
+        : [
+            {
+              activityId: transaction.activityId,
+              transactionId: item.transactionId,
+              transferItemType: item.transferItemType,
+              symbol: item.instrument?.symbol,
+              fee: item.fee,
+            },
+          ],
+    ),
+  );
+
+  return {
+    orderId,
+    totalFees: items.reduce((total, item) => total + item.fee, 0),
+    items,
+    transactions: matchingTransactions,
+  };
+}

--- a/src/orderEconomics.ts
+++ b/src/orderEconomics.ts
@@ -36,23 +36,30 @@ interface FillAccumulator {
   weightedPrice: number;
 }
 
+interface MatchingOrderLeg {
+  leg: SchwabOrderLeg;
+  index: number;
+}
+
 function matchingOrderLeg(
   executionLeg: SchwabExecutionLeg,
   orderLegs: SchwabOrderLeg[],
-): SchwabOrderLeg | undefined {
+): MatchingOrderLeg | undefined {
   if (executionLeg.legId !== undefined) {
-    const byLegId = orderLegs.find((leg) => leg.legId === executionLeg.legId);
-    if (byLegId) return byLegId;
+    const index = orderLegs.findIndex(
+      (leg) => leg.legId === executionLeg.legId,
+    );
+    if (index !== -1) return { leg: orderLegs[index], index };
   }
 
   if (executionLeg.instrumentId !== undefined) {
-    const byInstrumentId = orderLegs.find(
+    const index = orderLegs.findIndex(
       (leg) => leg.instrument?.instrumentId === executionLeg.instrumentId,
     );
-    if (byInstrumentId) return byInstrumentId;
+    if (index !== -1) return { leg: orderLegs[index], index };
   }
 
-  return orderLegs.length === 1 ? orderLegs[0] : undefined;
+  return orderLegs.length === 1 ? { leg: orderLegs[0], index: 0 } : undefined;
 }
 
 /**
@@ -79,17 +86,18 @@ export function getRealizedFills(order: SchwabOrder): SchwabRealizedFill[] {
         continue;
       }
 
-      const orderLeg = matchingOrderLeg(executionLeg, orderLegs);
+      const match = matchingOrderLeg(executionLeg, orderLegs);
+      const orderLeg = match?.leg;
       const legId = executionLeg.legId ?? orderLeg?.legId;
       const instrumentId =
         executionLeg.instrumentId ?? orderLeg?.instrument?.instrumentId;
       const key =
-        legId !== undefined
-          ? `leg:${String(legId)}`
-          : instrumentId !== undefined
-            ? `instrument:${String(instrumentId)}`
-            : orderLegs.length === 1
-              ? "single-leg"
+        match !== undefined
+          ? `order-leg:${String(match.index)}`
+          : legId !== undefined
+            ? `leg:${String(legId)}`
+            : instrumentId !== undefined
+              ? `instrument:${String(instrumentId)}`
               : undefined;
 
       // An execution leg without any usable correlation identifier cannot be

--- a/test/orderEconomics.test.js
+++ b/test/orderEconomics.test.js
@@ -100,6 +100,42 @@ test("getRealizedFills correlates by instrument id and skips incomplete fills", 
   ]);
 });
 
+test("getRealizedFills uses one bucket when execution identifiers vary", () => {
+  const fills = getRealizedFills({
+    orderLegCollection: [
+      {
+        instrument: {
+          assetType: "OPTION",
+          instrumentId: 404,
+          symbol: "SPY   260717P00550000",
+        },
+      },
+    ],
+    orderActivityCollection: [
+      {
+        activityType: "EXECUTION",
+        executionLegs: [
+          { legId: 7, instrumentId: 404, price: 1.2, quantity: 1 },
+        ],
+      },
+      {
+        activityType: "EXECUTION",
+        executionLegs: [{ instrumentId: 404, price: 1.5, quantity: 2 }],
+      },
+    ],
+  });
+
+  assert.deepEqual(fills, [
+    {
+      legId: 7,
+      instrumentId: 404,
+      symbol: "SPY   260717P00550000",
+      filledQuantity: 3,
+      averageFillPrice: 1.4000000000000001,
+    },
+  ]);
+});
+
 test("fetchAccountOrders preserves terminal order execution activities", async () => {
   const originalFetch = globalThis.fetch;
   const responseBody = [

--- a/test/orderEconomics.test.js
+++ b/test/orderEconomics.test.js
@@ -1,0 +1,220 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getOrderFees,
+  getRealizedFills,
+  SchwabClient,
+} from "../dist/index.js";
+
+test("getRealizedFills calculates quantity-weighted prices by order leg", () => {
+  const fills = getRealizedFills({
+    orderLegCollection: [
+      {
+        legId: 1,
+        instrument: {
+          assetType: "OPTION",
+          instrumentId: 101,
+          symbol: "SPY   260717C00600000",
+        },
+      },
+      {
+        legId: 2,
+        instrument: {
+          assetType: "OPTION",
+          instrumentId: 202,
+          symbol: "SPY   260717C00605000",
+        },
+      },
+    ],
+    orderActivityCollection: [
+      {
+        activityType: "EXECUTION",
+        executionLegs: [
+          { legId: 1, instrumentId: 101, price: 1.2, quantity: 1 },
+          { legId: 2, instrumentId: 202, price: 0.4, quantity: 2 },
+        ],
+      },
+      {
+        activityType: "EXECUTION",
+        executionLegs: [
+          { legId: 1, instrumentId: 101, price: 1.5, quantity: 2 },
+          { legId: 2, instrumentId: 202, price: 0.7, quantity: 1 },
+        ],
+      },
+      {
+        activityType: "ORDER_ACTION",
+        executionLegs: [{ legId: 1, price: 99, quantity: 99 }],
+      },
+    ],
+  });
+
+  assert.deepEqual(fills, [
+    {
+      legId: 1,
+      instrumentId: 101,
+      symbol: "SPY   260717C00600000",
+      filledQuantity: 3,
+      averageFillPrice: 1.4000000000000001,
+    },
+    {
+      legId: 2,
+      instrumentId: 202,
+      symbol: "SPY   260717C00605000",
+      filledQuantity: 3,
+      averageFillPrice: 0.5,
+    },
+  ]);
+});
+
+test("getRealizedFills correlates by instrument id and skips incomplete fills", () => {
+  const fills = getRealizedFills({
+    orderLegCollection: [
+      {
+        instrument: {
+          assetType: "EQUITY",
+          instrumentId: 303,
+          symbol: "AAPL",
+        },
+      },
+    ],
+    orderActivityCollection: [
+      {
+        activityType: "EXECUTION",
+        executionLegs: [
+          { instrumentId: 303, price: 210, quantity: 5 },
+          { instrumentId: 303, quantity: 2 },
+        ],
+      },
+    ],
+  });
+
+  assert.deepEqual(fills, [
+    {
+      legId: undefined,
+      instrumentId: 303,
+      symbol: "AAPL",
+      filledQuantity: 5,
+      averageFillPrice: 210,
+    },
+  ]);
+});
+
+test("fetchAccountOrders preserves terminal order execution activities", async () => {
+  const originalFetch = globalThis.fetch;
+  const responseBody = [
+    {
+      orderId: 52,
+      status: "FILLED",
+      orderActivityCollection: [
+        {
+          activityType: "EXECUTION",
+          executionType: "FILL",
+          executionLegs: [{ legId: 1, price: 1.25, quantity: 2 }],
+        },
+      ],
+    },
+  ];
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  try {
+    const client = new SchwabClient("token");
+    const orders = await client.fetchAccountOrders("account-hash", {
+      fromEnteredTime: new Date("2026-07-01T00:00:00Z"),
+      toEnteredTime: new Date("2026-07-13T00:00:00Z"),
+      status: "FILLED",
+    });
+
+    assert.deepEqual(orders, responseBody);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("getOrderFees correlates TRADE transactions by order id", () => {
+  const transactions = [
+    {
+      activityId: 10,
+      time: "2026-07-13T10:00:00Z",
+      accountNumber: "123",
+      type: "TRADE",
+      status: "VALID",
+      subAccount: "CASH",
+      tradeDate: "2026-07-13",
+      positionId: 1,
+      orderId: 52,
+      netAmount: 119.25,
+      transferItems: [
+        {
+          transactionId: 1001,
+          transferItemType: "OPTION",
+          instrument: { symbol: "SPY   260717C00600000" },
+          fee: 0.65,
+        },
+        {
+          transactionId: 1002,
+          transferItemType: "FEE",
+          fee: 0.1,
+        },
+      ],
+    },
+    {
+      activityId: 11,
+      time: "2026-07-13T10:00:00Z",
+      accountNumber: "123",
+      type: "DIVIDEND_OR_INTEREST",
+      status: "VALID",
+      subAccount: "CASH",
+      tradeDate: "2026-07-13",
+      positionId: 1,
+      orderId: 52,
+      netAmount: 1,
+      transferItems: [{ fee: 50 }],
+    },
+    {
+      activityId: 12,
+      time: "2026-07-13T10:00:00Z",
+      accountNumber: "123",
+      type: "TRADE",
+      status: "VALID",
+      subAccount: "CASH",
+      tradeDate: "2026-07-13",
+      positionId: 1,
+      orderId: 99,
+      netAmount: 1,
+      transferItems: [{ fee: 75 }],
+    },
+  ];
+
+  const result = getOrderFees({ orderId: 52 }, transactions);
+
+  assert.equal(result.totalFees, 0.75);
+  assert.equal(result.transactions.length, 1);
+  assert.deepEqual(result.items, [
+    {
+      activityId: 10,
+      transactionId: 1001,
+      transferItemType: "OPTION",
+      symbol: "SPY   260717C00600000",
+      fee: 0.65,
+    },
+    {
+      activityId: 10,
+      transactionId: 1002,
+      transferItemType: "FEE",
+      symbol: undefined,
+      fee: 0.1,
+    },
+  ]);
+});
+
+test("getOrderFees rejects an order without an id", () => {
+  assert.throws(
+    () => getOrderFees({}, []),
+    /A valid order id is required to correlate order fees/,
+  );
+});


### PR DESCRIPTION
## Summary

- add `getRealizedFills()` to aggregate partial and serial executions into quantity-weighted per-leg fill prices
- correlate execution legs to order-leg symbols by leg ID or instrument ID
- add `getOrderFees()` to correlate fee-bearing `TRADE` transactions by order ID while preserving Schwab's raw fee metadata
- document the order-economics workflow and verify that terminal-order execution activities pass through unchanged

## Why

The Schwab payload already contains execution activities and transaction fees, but callers had to independently implement fragile fill aggregation and cross-endpoint correlation. This provides a small public derivation surface for actual fill economics and unblocks downstream strategy accounting.

Closes #52.

## Validation

- `npm test`
- `npm run lint`
- `npm run format:check`
