### PR TITLE
Expose Schwab marginBalance in getAccountBalances

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ const option = await client.getOptionQuote({
 const balances = await client.getAccountBalances();
 console.log(`Equity: $${balances.equity}`);
 console.log(`Buying Power: $${balances.buyingPower}`);
+console.log(`Available Funds: $${balances.availableFunds}`);
+console.log(`Margin Balance: $${balances.marginBalance}`);
 console.log(`Cash: $${balances.cashBalance}`);
 ```
 

--- a/src/schwabApiTypes.ts
+++ b/src/schwabApiTypes.ts
@@ -3,6 +3,7 @@ export interface SchwabAccountDetails {
   positions: SchwabAccountPosition[];
   liquidationValue: number;
   availableFunds: number;
+  marginBalance: number;
   buyingPower: number;
   cashBalance: number;
 }
@@ -31,6 +32,7 @@ export interface SchwabAccount {
     currentBalances: {
       equity: number;
       availableFunds: number;
+      marginBalance: number;
       buyingPower: number;
       cashBalance: number;
       liquidationValue: number;

--- a/src/schwabClient.ts
+++ b/src/schwabClient.ts
@@ -287,6 +287,7 @@ export class SchwabClient {
     liquidationValue: number;
     cashBalance: number;
     availableFunds: number;
+    marginBalance: number;
     buyingPower: number;
     equity: number;
   }> {
@@ -301,6 +302,7 @@ export class SchwabClient {
       liquidationValue: balances.liquidationValue,
       cashBalance: balances.cashBalance,
       availableFunds: balances.availableFunds,
+      marginBalance: balances.marginBalance,
       buyingPower: balances.buyingPower,
       equity: balances.equity,
     };

--- a/test/accountBalances.test.js
+++ b/test/accountBalances.test.js
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { SchwabClient } from "../dist/index.js";
+
+test("getAccountBalances returns distinct available funds and margin balance", async () => {
+  const originalFetch = globalThis.fetch;
+  const responseBody = [
+    {
+      securitiesAccount: {
+        accountNumber: "123456789",
+        positions: [],
+        currentBalances: {
+          liquidationValue: 10000,
+          cashBalance: 1500,
+          availableFunds: 2500,
+          marginBalance: 3750,
+          buyingPower: 5000,
+          equity: 9000,
+        },
+      },
+    },
+  ];
+
+  globalThis.fetch = async () =>
+    new Response(JSON.stringify(responseBody), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+  try {
+    const balances = await new SchwabClient("token").getAccountBalances();
+
+    assert.deepEqual(balances, {
+      liquidationValue: 10000,
+      cashBalance: 1500,
+      availableFunds: 2500,
+      marginBalance: 3750,
+      buyingPower: 5000,
+      equity: 9000,
+    });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
### Motivation

- The Schwab Trader API returns a distinct `marginBalance` value that was not exposed by the client, preventing consumers from accessing the true margin balance separate from `availableFunds`.
- This change ensures `marginBalance` is available to callers and documented as its own field rather than derived from other values.

### Description

- Add `marginBalance` to the public `SchwabAccountDetails` and raw `SchwabAccount.securitiesAccount.currentBalances` types in `src/schwabApiTypes.ts`.
- Update `SchwabClient.getAccountBalances()` in `src/schwabClient.ts` to include `marginBalance` in the return type and returned object from `currentBalances`.
- Add a regression test `test/accountBalances.test.js` that verifies `availableFunds` and `marginBalance` are returned as distinct values.
- Update the README example to show `availableFunds` and `marginBalance` in the `getAccountBalances()` usage example.

### Testing

- Ran `npm test`, which executes `tsc` and `node --test test/*.test.js`, and the test suite completed successfully.
- The new `test/accountBalances.test.js` passed along with the existing tests (total: 10 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a724439a304832c89ab9c76e89f06e3)

Fixes #59 