### PR TITLE
Return full Schwab `currentBalances` from `getAccountBalances`

### DIFF
--- a/src/schwabApiTypes.ts
+++ b/src/schwabApiTypes.ts
@@ -23,20 +23,37 @@ export interface SchwabAccountPosition {
 }
 
 // Raw API types
+export interface SchwabCurrentBalances {
+  availableFunds: number;
+  availableFundsNonMarginableTrade: number;
+  buyingPower: number;
+  buyingPowerNonMarginableTrade: number;
+  dayTradingBuyingPower: number;
+  dayTradingBuyingPowerCall: number;
+  equity: number;
+  equityPercentage: number;
+  longMarginValue: number;
+  maintenanceCall: number;
+  maintenanceRequirement: number;
+  marginBalance: number;
+  regTCall: number;
+  shortBalance: number;
+  shortMarginValue: number;
+  sma: number;
+  isInCall: number;
+  stockBuyingPower: number;
+  optionBuyingPower: number;
+  cashBalance: number;
+  liquidationValue: number;
+}
+
 export interface SchwabAccount {
   hashValue?: string;
   securitiesAccount: {
     accountNumber: string;
     hashValue?: string;
     positions: SchwabPosition[];
-    currentBalances: {
-      equity: number;
-      availableFunds: number;
-      marginBalance: number;
-      buyingPower: number;
-      cashBalance: number;
-      liquidationValue: number;
-    };
+    currentBalances: SchwabCurrentBalances;
   };
 }
 

--- a/src/schwabClient.ts
+++ b/src/schwabClient.ts
@@ -16,6 +16,7 @@ import type {
 import type {
   SchwabAccount,
   SchwabAccountTransactionHistory,
+  SchwabCurrentBalances,
   SchwabPosition,
   SchwabTransaction,
   SchwabUserPreference,
@@ -283,29 +284,14 @@ export class SchwabClient {
     return accounts[0].securitiesAccount.currentBalances.liquidationValue;
   }
 
-  async getAccountBalances(): Promise<{
-    liquidationValue: number;
-    cashBalance: number;
-    availableFunds: number;
-    marginBalance: number;
-    buyingPower: number;
-    equity: number;
-  }> {
+  async getAccountBalances(): Promise<SchwabCurrentBalances> {
     const accounts = await this.makeApiRequest<SchwabAccount[]>(
       "/trader/v1/accounts?fields=positions",
     );
     if (accounts.length === 0) {
       throw new Error("No Schwab account found");
     }
-    const balances = accounts[0].securitiesAccount.currentBalances;
-    return {
-      liquidationValue: balances.liquidationValue,
-      cashBalance: balances.cashBalance,
-      availableFunds: balances.availableFunds,
-      marginBalance: balances.marginBalance,
-      buyingPower: balances.buyingPower,
-      equity: balances.equity,
-    };
+    return accounts[0].securitiesAccount.currentBalances;
   }
 
   async getPositions(symbol?: string): Promise<SchwabPosition[]> {

--- a/test/accountBalances.test.js
+++ b/test/accountBalances.test.js
@@ -11,12 +11,27 @@ test("getAccountBalances returns distinct available funds and margin balance", a
         accountNumber: "123456789",
         positions: [],
         currentBalances: {
+          availableFunds: 2500,
+          availableFundsNonMarginableTrade: 2400,
+          buyingPower: 5000,
+          buyingPowerNonMarginableTrade: 4800,
+          dayTradingBuyingPower: 10000,
+          dayTradingBuyingPowerCall: 0,
+          equity: 9000,
+          equityPercentage: 90,
+          longMarginValue: 8000,
+          maintenanceCall: 0,
+          maintenanceRequirement: 1200,
+          marginBalance: 3750,
+          regTCall: 0,
+          shortBalance: 0,
+          shortMarginValue: 0,
+          sma: 3000,
+          isInCall: 0,
+          stockBuyingPower: 5000,
+          optionBuyingPower: 4500,
           liquidationValue: 10000,
           cashBalance: 1500,
-          availableFunds: 2500,
-          marginBalance: 3750,
-          buyingPower: 5000,
-          equity: 9000,
         },
       },
     },
@@ -31,14 +46,7 @@ test("getAccountBalances returns distinct available funds and margin balance", a
   try {
     const balances = await new SchwabClient("token").getAccountBalances();
 
-    assert.deepEqual(balances, {
-      liquidationValue: 10000,
-      cashBalance: 1500,
-      availableFunds: 2500,
-      marginBalance: 3750,
-      buyingPower: 5000,
-      equity: 9000,
-    });
+    assert.deepEqual(balances, responseBody[0].securitiesAccount.currentBalances);
   } finally {
     globalThis.fetch = originalFetch;
   }


### PR DESCRIPTION
### Motivation

- Ensure the client surfaces the complete Schwab `currentBalances` payload so callers can access all balance fields the API provides.

### Description

- Add a new `SchwabCurrentBalances` type describing the full `currentBalances` schema and replace the inline subset with `SchwabCurrentBalances` in `SchwabAccount` (`src/schwabApiTypes.ts`).
- Change `getAccountBalances()` to return `SchwabCurrentBalances` and return the raw `securitiesAccount.currentBalances` object (`src/schwabClient.ts`).
- Update the unit test fixture to include the full `currentBalances` object and assert that `getAccountBalances()` preserves the full response (`test/accountBalances.test.js`).

### Testing

- Ran `npm test` which builds and executes the test suite and all tests passed (10/10). 
- Ran `npm run format:check` and formatting checks passed. 
- Ran `npm run lint` and the linter completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a724db38528832ca1c88400c94a5f23)