### PR TITLE
feat: expose option quote freshness metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@huskly/schwab-client",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Schwab Market Data and Trading API client",
   "type": "module",
   "main": "dist/index.js",

--- a/src/schwabClient.ts
+++ b/src/schwabClient.ts
@@ -25,9 +25,24 @@ import { differenceInDays, format, parse, startOfYear } from "date-fns";
 
 const SCHWAB_API_BASE_URL = "https://api.schwabapi.com";
 
+/**
+ * Normalize a Schwab epoch-millisecond field into a usable timestamp.
+ *
+ * Schwab reports an unknown timestamp as `0`, `null`, or an absent field. All three mean the
+ * same thing to a consumer - "this provider did not tell me when the data is from" - so they
+ * collapse to `null` rather than to a 1970 date that would look like extremely stale data.
+ */
+function epochMillis(value: number | null | undefined): number | null {
+  if (value === null || value === undefined) return null;
+  if (!Number.isFinite(value) || value <= 0) return null;
+  return value;
+}
+
 interface SchwabOptionChainResponse {
   symbol: string;
   status: string;
+  /** Schwab marks the whole chain response delayed or live; absent on some responses. */
+  isDelayed?: boolean;
   underlying?: { symbol: string; last: number };
   putExpDateMap?: Record<string, Record<string, SchwabOptionContract[]>>;
   callExpDateMap?: Record<string, Record<string, SchwabOptionContract[]>>;
@@ -35,6 +50,8 @@ interface SchwabOptionChainResponse {
 
 interface SchwabOptionContract {
   putCall: "PUT" | "CALL";
+  quoteTimeInLong?: number | null;
+  tradeTimeInLong?: number | null;
   symbol: string;
   description: string;
   exchangeName: string;
@@ -248,6 +265,9 @@ export class SchwabClient {
               delta: contract.delta,
               volume: contract.totalVolume ?? null,
               openInterest: contract.openInterest ?? null,
+              quoteTime: epochMillis(contract.quoteTimeInLong),
+              tradeTime: epochMillis(contract.tradeTimeInLong),
+              delayed: data.isDelayed ?? null,
             });
           }
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -99,6 +99,15 @@ export interface OptionQuote {
   delta: number; // negative for puts
   volume: number | null;
   openInterest: number | null;
+  /** Provider quote timestamp in epoch milliseconds; null when Schwab omits it. */
+  quoteTime: number | null;
+  /** Provider last-trade timestamp in epoch milliseconds; null when Schwab omits it. */
+  tradeTime: number | null;
+  /**
+   * Whether Schwab marked this chain response as delayed data. `null` means the response did
+   * not say, which a consumer must not read as "live".
+   */
+  delayed: boolean | null;
 }
 
 export interface PutCreditSpread {

--- a/test/optionChain.test.js
+++ b/test/optionChain.test.js
@@ -95,3 +95,135 @@ test("getOptionChain preserves populated, missing, and zero activity values", as
     globalThis.fetch = originalFetch;
   }
 });
+
+test("getOptionChain preserves quote freshness metadata and represents unknown values as null", async () => {
+  const originalFetch = globalThis.fetch;
+  const contract = {
+    putCall: "CALL",
+    description: "SPY option",
+    exchangeName: "OPR",
+    bid: 1,
+    ask: 1.2,
+    last: 1.1,
+    mark: 1.1,
+    bidSize: 10,
+    askSize: 12,
+    lastSize: 1,
+    highPrice: 1.3,
+    lowPrice: 0.9,
+    openPrice: 1,
+    tradeDate: null,
+    delta: 0.5,
+    gamma: 0.02,
+    theta: -0.01,
+    vega: 0.1,
+    rho: 0.01,
+    expirationDate: "2026-08-21T20:00:00.000+00:00",
+    daysToExpiration: 24,
+    expirationType: "S",
+    multiplier: 100,
+    settlementType: "P",
+    inTheMoney: false,
+  };
+  const cases = [
+    {
+      // Populated timestamps survive unchanged.
+      body: {
+        symbol: "SPY",
+        status: "SUCCESS",
+        isDelayed: false,
+        callExpDateMap: {
+          "2026-08-21:24": {
+            "600.0": [
+              {
+                ...contract,
+                symbol: "SPY   260821C00600000",
+                strikePrice: 600,
+                quoteTimeInLong: 1787000000000,
+                tradeTimeInLong: 1786999999000,
+              },
+            ],
+          },
+        },
+      },
+      expected: {
+        quoteTime: 1787000000000,
+        tradeTime: 1786999999000,
+        delayed: false,
+      },
+    },
+    {
+      // Delayed data stays visibly delayed.
+      body: {
+        symbol: "SPY",
+        status: "SUCCESS",
+        isDelayed: true,
+        callExpDateMap: {
+          "2026-08-21:24": {
+            "600.0": [
+              {
+                ...contract,
+                symbol: "SPY   260821C00600000",
+                strikePrice: 600,
+                quoteTimeInLong: 1787000000000,
+                tradeTimeInLong: 1786999999000,
+              },
+            ],
+          },
+        },
+      },
+      expected: {
+        quoteTime: 1787000000000,
+        tradeTime: 1786999999000,
+        delayed: true,
+      },
+    },
+    {
+      // Absent, null, and zero timestamps all mean "unknown", never 1970.
+      body: {
+        symbol: "SPY",
+        status: "SUCCESS",
+        callExpDateMap: {
+          "2026-08-21:24": {
+            "600.0": [
+              {
+                ...contract,
+                symbol: "SPY   260821C00600000",
+                strikePrice: 600,
+                quoteTimeInLong: 0,
+                tradeTimeInLong: null,
+              },
+            ],
+          },
+        },
+      },
+      expected: { quoteTime: null, tradeTime: null, delayed: null },
+    },
+  ];
+
+  try {
+    for (const { body, expected } of cases) {
+      globalThis.fetch = async () =>
+        new Response(JSON.stringify(body), {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      const options = await new SchwabClient("token").getOptionChain(
+        "SPY",
+        new Date("2026-08-21T00:00:00Z"),
+      );
+      assert.equal(options.length, 1);
+      const [option] = options;
+      assert.deepEqual(
+        {
+          quoteTime: option.quoteTime,
+          tradeTime: option.tradeTime,
+          delayed: option.delayed,
+        },
+        expected,
+      );
+    }
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});


### PR DESCRIPTION
## Why

`strategy-runner` needs a market-data freshness contract before it places live orders (felipecsl/convex-ridge#388). Today `getOptionChain` drops every timestamp Schwab supplies, so a consumer cannot tell a current quote from a cached or delayed one.

## What

- `OptionQuote` now carries `quoteTime`, `tradeTime`, and `delayed`.
- `getOptionChain` maps `quoteTimeInLong` / `tradeTimeInLong` per contract and the response-level `isDelayed` flag.
- Unknown provider values (absent, `null`, or `0`) become `null`, never a 1970 date that would look like very stale data. `delayed: null` means "Schwab did not say" and must not be read as live.

## Tests

New coverage for populated timestamps, delayed responses, and absent/null/zero timestamps.